### PR TITLE
Update python_version for 3.13

### DIFF
--- a/microsoftsqlserver.json
+++ b/microsoftsqlserver.json
@@ -16,7 +16,7 @@
     "main_module": "microsoftsqlserver_connector.py",
     "min_phantom_version": "6.3.0",
     "app_wizard_version": "1.0.0",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "Microsoft SQL Server 2019"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)